### PR TITLE
Make strictExportPresence default to true

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -27,7 +27,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("module.wrappedContextRegExp", /.*/);
 		this.set("module.wrappedContextRecursive", true);
 		this.set("module.wrappedContextCritical", false);
-		this.set("module.strictExportPresence", false);
+		this.set("module.strictExportPresence", true);
 
 		this.set("module.unsafeCache", true);
 


### PR DESCRIPTION
Changes the default option for strictExportPresence to true

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
a default settings change
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Opens to discuss if we want it like this.
It changes `module.strictExportPresence` to be `true` by default since in my experience if you import something that doesn't exists you want it to be a error and not a warning.


```
// App.js
import { DepositPage } from './DepositPage';

// DepositPage.js
export default function DepositPage() {
  return <h1>Make a deposit</h1>;
}
```

The code above would be fine since it will only print a warning but at runtime it will crash since there are no export for the import specifier.

What this change does is making that warning becoming a error instead.
https://github.com/webpack/webpack/blob/3afd802c9a5a22ee42bb2395307ce50dbbd3a3aa/lib/dependencies/HarmonyImportSpecifierDependency.js#L31-L43
<img width="651" alt="screen shot 2017-03-30 at 11 20 21" src="https://cloud.githubusercontent.com/assets/3890572/24497204/f3836aea-153a-11e7-9682-980bbec0ae2e.png">
vs
<img width="649" alt="screen shot 2017-03-30 at 11 20 35" src="https://cloud.githubusercontent.com/assets/3890572/24497206/f5476782-153a-11e7-8180-30906c6d6bda.png">

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
It might do if some people rely on unknown exports.
if so you would need to set `module.strictExportPresence` to `false`
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
